### PR TITLE
Remove flying glimr references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ spec/dummy/db/
 spec/dummy/db/*
 spec/dummy/tmp/*
 spec/dummy/tmp/
+*.gem

--- a/lib/govuk_pay_api_client/version.rb
+++ b/lib/govuk_pay_api_client/version.rb
@@ -1,3 +1,3 @@
 module GovukPayApiClient
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end

--- a/shared_examples/shared_examples_for_govpay.rb
+++ b/shared_examples/shared_examples_for_govpay.rb
@@ -1,29 +1,5 @@
 module GovpayExample
   module Mocks
-    def glimr_api_call
-      class_double(
-        Excon,
-        'glimr availability check',
-        post: instance_double(
-          Excon::Response,
-          status: 200,
-          body: { glimrAvailable: 'yes' }.to_json
-        )
-      )
-    end
-
-    def a_create_payment_success(initial_payment_response)
-      class_double(
-        Excon,
-        'glimr availability check',
-        post: instance_double(
-          Excon::Response,
-          status: 200,
-          body: initial_payment_response
-        )
-      )
-    end
-
     def a_create_payment_timeout
       class_double(Excon, 'create payment timeout').tap { |ex|
         expect(ex).to receive(:post).and_raise(Excon::Errors::Timeout)

--- a/spec/support/shared_examples_for_govpay.rb
+++ b/spec/support/shared_examples_for_govpay.rb
@@ -1,29 +1,5 @@
 module GovpayExample
   module Mocks
-    def glimr_api_call
-      class_double(
-        Excon,
-        'glimr availability check',
-        post: instance_double(
-          Excon::Response,
-          status: 200,
-          body: { glimrAvailable: 'yes' }.to_json
-        )
-      )
-    end
-
-    def a_create_payment_success(initial_payment_response)
-      class_double(
-        Excon,
-        'glimr availability check',
-        post: instance_double(
-          Excon::Response,
-          status: 200,
-          body: initial_payment_response
-        )
-      )
-    end
-
     def a_create_payment_timeout
       class_double(Excon, 'create payment timeout').tap { |ex|
         expect(ex).to receive(:post).and_raise(Excon::Errors::Timeout)


### PR DESCRIPTION
Some GLiMR lint got left in from the port, but was not being called from anywhere. 
