### PR TITLE
Allow the app access to the Govuk Pay payment_id

### DIFF
--- a/lib/govuk_pay_api_client/create_payment.rb
+++ b/lib/govuk_pay_api_client/create_payment.rb
@@ -23,7 +23,8 @@ module GovukPayApiClient
 
     def parsed_response
       OpenStruct.new(
-        next_url: response_body.fetch(:_links).fetch(:next_url).fetch(:href)
+        next_url: response_body.fetch(:_links).fetch(:next_url).fetch(:href),
+        payment_id: response_body.fetch(:payment_id)
       )
     end
 

--- a/lib/govuk_pay_api_client/version.rb
+++ b/lib/govuk_pay_api_client/version.rb
@@ -1,3 +1,3 @@
 module GovukPayApiClient
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end

--- a/spec/govuk_pay_api_client/lib/create_payment_spec.rb
+++ b/spec/govuk_pay_api_client/lib/create_payment_spec.rb
@@ -25,6 +25,10 @@ RSpec.describe GovukPayApiClient::CreatePayment do
     )
   end
 
+  it 'exposes the payment_id provided by the api' do
+    expect(subject.payment_id).to eq('rmpaurrjuehgpvtqg997bt50f')
+  end
+
   it 'requires a fee object' do
     expect {
       described_class.call(nil, 'the_return_url')


### PR DESCRIPTION
This was an oversight in the previous version.
