### PR TITLE
Use arbitrary api path

### DIFF
--- a/lib/govuk_pay_api_client/api.rb
+++ b/lib/govuk_pay_api_client/api.rb
@@ -11,23 +11,21 @@ module GovukPayApiClient
     end
 
     def post
-      @post ||=
-        client.post(path: endpoint, body: request_body.to_json).tap { |resp|
-          # Only timeouts and network issues raise errors.
-          handle_response_errors(resp)
-          @body = resp.body
-        }
+      client("#{api_url}#{endpoint}").post(body: request_body.to_json).tap { |resp|
+        # Only timeouts and network issues raise errors.
+        handle_response_errors(resp)
+        @body = resp.body
+      }
     rescue Excon::Error => e
       raise Unavailable, e
     end
 
     def get
-      @get ||=
-        client.get(path: endpoint).tap { |resp|
-          # Only timeouts and network issues raise errors.
-          handle_response_errors(resp)
-          @body = resp.body
-        }
+      client("#{api_url}#{endpoint}").get.tap { |resp|
+        # Only timeouts and network issues raise errors.
+        handle_response_errors(resp)
+        @body = resp.body
+      }
     rescue Excon::Error => e
       raise Unavailable, e
     end
@@ -46,9 +44,13 @@ module GovukPayApiClient
       end
     end
 
-    def client
-      @client ||= Excon.new(
-        ENV.fetch('GOVUK_PAY_API_URL'),
+    def api_url
+      ENV.fetch('GOVUK_PAY_API_URL')
+    end
+
+    def client(uri)
+      Excon.new(
+        uri,
         headers: {
           'Authorization' => "Bearer #{ENV.fetch('GOVUK_PAY_API_KEY')}",
           'Content-Type' => 'application/json',

--- a/spec/features/process_payment_spec.rb
+++ b/spec/features/process_payment_spec.rb
@@ -66,6 +66,7 @@ RSpec.feature 'process payment' do
     end
 
     context 'govuk get_status returns a 500' do
+      let(:docpath) { '/v1' }
       include_examples 'govpay post_pay returns a 500', govpay_payment_id
 
       it 'alerts the user to the failure' do

--- a/spec/govuk_pay_api_client/lib/api/get_spec.rb
+++ b/spec/govuk_pay_api_client/lib/api/get_spec.rb
@@ -2,6 +2,10 @@ require 'rails_helper'
 require 'support/shared_examples_for_api_calls'
 
 RSpec.describe GovukPayApiClient::Api, '#get' do
+  let(:docpath) { '/v1' }
+  let(:api_endpoint) { 'endpoint' }
+  let(:path) { [docpath, api_endpoint].join('/') }
+
   include_examples 'anonymous object'
 
   it 'exposes an excon client' do
@@ -13,7 +17,7 @@ RSpec.describe GovukPayApiClient::Api, '#get' do
           "Content-Type" => "application/json",
           "Accept" => "application/json"
         },
-        path: '/endpoint',
+        path: path,
         persistent: true
       },
       status: 200, body: { response: 'response' }.to_json
@@ -29,7 +33,7 @@ RSpec.describe GovukPayApiClient::Api, '#get' do
       Excon.stub(
         {
           method: :get,
-          path: '/endpoint',
+          path: path,
         },
         status: 404
       )
@@ -40,7 +44,7 @@ RSpec.describe GovukPayApiClient::Api, '#get' do
       Excon.stub(
         {
           method: :get,
-          path: '/endpoint',
+          path: path,
         },
         status: 500
       )
@@ -53,7 +57,7 @@ RSpec.describe GovukPayApiClient::Api, '#get' do
       Excon.stub(
         {
           method: :get,
-          path: '/endpoint',
+          path: path,
         },
         status: 400
       )
@@ -64,7 +68,7 @@ RSpec.describe GovukPayApiClient::Api, '#get' do
       Excon.stub(
         {
           method: :get,
-          path: '/endpoint',
+          path: path,
         },
         status: 599
       )
@@ -77,7 +81,7 @@ RSpec.describe GovukPayApiClient::Api, '#get' do
       Excon.stub(
         {
           method: :get,
-          path: '/endpoint',
+          path: path,
         },
         status: 399
       )
@@ -88,26 +92,11 @@ RSpec.describe GovukPayApiClient::Api, '#get' do
       Excon.stub(
         {
           method: :get,
-          path: '/endpoint',
+          path: path,
         },
         status: 600
       )
       expect { object.get }.not_to raise_error
-    end
-  end
-
-  context 'the client dies without returning' do
-    let(:excon) {
-      class_double(Excon)
-    }
-
-    before do
-      expect(excon).to receive(:get).and_raise(Excon::Error, 'it died')
-      expect(object).to receive(:client).and_return(excon)
-    end
-
-    it 'raises an exception if the client dies' do
-      expect { object.get }.to raise_error(GovukPayApiClient::Unavailable, 'it died')
     end
   end
 
@@ -120,7 +109,7 @@ RSpec.describe GovukPayApiClient::Api, '#get' do
           "Content-Type" => "application/json",
           "Accept" => "application/json"
         },
-        path: '/endpoint',
+        path: path,
         persistent: true
       },
       status: 201

--- a/spec/govuk_pay_api_client/lib/api/get_spec.rb
+++ b/spec/govuk_pay_api_client/lib/api/get_spec.rb
@@ -8,6 +8,20 @@ RSpec.describe GovukPayApiClient::Api, '#get' do
 
   include_examples 'anonymous object'
 
+  context 'the client dies without returning' do
+    let(:client) { Object.new }
+
+    before do
+      allow(Excon).to receive(:new).and_return(client)
+      allow(client).to receive(:get).and_raise(Excon::Error, 'it died')
+    end
+
+    it 'raises an exception if the client dies' do
+      expect { object.get }.to raise_error(GovukPayApiClient::Unavailable, 'it died')
+    end
+  end
+
+
   it 'exposes an excon client' do
     Excon.stub(
       {

--- a/spec/govuk_pay_api_client/lib/api/post_spec.rb
+++ b/spec/govuk_pay_api_client/lib/api/post_spec.rb
@@ -2,6 +2,10 @@ require 'rails_helper'
 require 'support/shared_examples_for_api_calls'
 
 RSpec.describe GovukPayApiClient::Api, '#post' do
+  let(:docpath) { '/v1' }
+  let(:api_endpoint) { 'endpoint' }
+  let(:path) { [docpath, api_endpoint].join('/') }
+
   include_examples 'anonymous object'
 
   it 'exposes an excon client' do
@@ -14,7 +18,7 @@ RSpec.describe GovukPayApiClient::Api, '#post' do
           "Content-Type" => "application/json",
           "Accept" => "application/json"
         },
-        path: '/endpoint',
+        path: path,
         persistent: true
       },
       status: 200, body: { response: 'response' }.to_json
@@ -30,7 +34,7 @@ RSpec.describe GovukPayApiClient::Api, '#post' do
       Excon.stub(
         {
           method: :post,
-          path: '/endpoint',
+          path: path,
         },
         status: 404
       )
@@ -41,7 +45,7 @@ RSpec.describe GovukPayApiClient::Api, '#post' do
       Excon.stub(
         {
           method: :post,
-          path: '/endpoint',
+          path: path,
         },
         status: 500
       )

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-ENV['GOVUK_PAY_API_URL'] = 'https://govpay-test.dsd.io'
+ENV['GOVUK_PAY_API_URL'] = 'https://govpay-test.dsd.io/v1'
 ENV['GOVUK_PAY_API_KEY'] = 'deadbeef'
 require 'govuk_pay_api_client'

--- a/spec/support/shared_examples_for_govpay.rb
+++ b/spec/support/shared_examples_for_govpay.rb
@@ -1,5 +1,9 @@
 module GovpayExample
   module Responses
+    def docpath
+      '/v1'
+    end
+
     def initial_payment_response(payment_id = 'rmpaurrjuehgpvtqg997bt50f')
       {
         'payment_id' => payment_id,
@@ -74,7 +78,7 @@ RSpec.shared_examples 'govpay payment response' do |fee, govpay_payment_id|
         method: :post,
         host: 'govpay-test.dsd.io',
         body: request_body,
-        path: '/payments'
+        path: "#{docpath}/payments"
       },
       status: 201, body: initial_payment_response(govpay_payment_id)
     )
@@ -83,7 +87,7 @@ RSpec.shared_examples 'govpay payment response' do |fee, govpay_payment_id|
       {
         method: :get,
         host: 'govpay-test.dsd.io',
-        path: "/payments/#{govpay_payment_id}"
+        path: "#{docpath}/payments/#{govpay_payment_id}"
       },
       status: 200, body: post_pay_response
     )
@@ -107,7 +111,7 @@ RSpec.shared_examples 'govpay returns a 404' do |fee|
         method: :post,
         host: 'govpay-test.dsd.io',
         body: request_body,
-        path: '/payments'
+        path: "#{docpath}/payments"
       },
       status: 404
     )
@@ -120,7 +124,7 @@ RSpec.shared_examples 'govpay post_pay returns a 500' do |govpay_payment_id|
       {
         method: :get,
         host: 'govpay-test.dsd.io',
-        path: "/payments/#{govpay_payment_id}"
+        path: "#{docpath}/payments/#{govpay_payment_id}"
       },
       status: 500, body: '{"message":"Govpay is not working"}'
     )
@@ -135,7 +139,7 @@ RSpec.shared_examples 'govpay payment status times out' do |govpay_payment_id|
       {
         method: :get,
         host: 'govpay-test.dsd.io',
-        path: "/payments/#{govpay_payment_id}"
+        path: "#{docpath}/payments/#{govpay_payment_id}"
       }
     ) { raise Excon::Errors::Timeout }
   end
@@ -149,7 +153,7 @@ RSpec.shared_examples 'govpay create payment times out' do
       {
         method: :post,
         host: 'govpay-test.dsd.io',
-        path: '/payments'
+        path: "#{docpath}/payments"
       }
     ) { raise Excon::Errors::Timeout }
   end


### PR DESCRIPTION
This solves the problem of the api endpoints requiring arbitrary path data. 